### PR TITLE
Remove langgraph SDK from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Gemini Fullstack LangGraph Quickstart
+# Gemini Fullstack Quickstart
 
-This project demonstrates a fullstack application using a React frontend and a LangGraph-powered backend agent. The agent is designed to perform comprehensive research on a user's query by dynamically generating search terms, querying the web using Google Search, reflecting on the results to identify knowledge gaps, and iteratively refining its search until it can provide a well-supported answer with citations. This application serves as an example of building research-augmented conversational AI using LangGraph and Google's Gemini models.
+This project demonstrates a fullstack application using a React frontend and a streaming backend agent. The agent performs comprehensive research on a user's query by dynamically generating search terms, querying the web using Google Search, reflecting on the results to identify knowledge gaps, and iteratively refining its search until it can provide a well-supported answer with citations. It serves as an example of building research-augmented conversational AI using Google's Gemini models.
 
-![Gemini Fullstack LangGraph](./app.png)
+![Gemini Fullstack](./app.png)
 
 ## Features
 
-- 💬 Fullstack application with a React frontend and LangGraph backend.
-- 🧠 Powered by a LangGraph agent for advanced research and conversational AI.
+- 💬 Fullstack application with a React frontend and FastAPI backend.
+- 🧠 Powered by a research agent for advanced conversational AI.
 - 🔍 Dynamic search query generation using Google Gemini models.
 - 🌐 Integrated web research via Google Search API.
 - 🤔 Reflective reasoning to identify knowledge gaps and refine searches.
@@ -19,7 +19,7 @@ This project demonstrates a fullstack application using a React frontend and a L
 The project is divided into two main directories:
 
 -   `frontend/`: Contains the React application built with Vite.
--   `backend/`: Contains the LangGraph/FastAPI application, including the research agent logic.
+ -   `backend/`: Contains the FastAPI application, including the research agent logic.
 
 ## Getting Started: Development and Local Testing
 
@@ -57,13 +57,13 @@ npm install
 ```bash
 make dev
 ```
-This will run the backend and frontend development servers.    Open your browser and navigate to the frontend development server URL (e.g., `http://localhost:5173/app`).
+This will run the backend and frontend development servers. Open your browser and navigate to the frontend development server URL (e.g., `http://localhost:5173/app`).
 
-_Alternatively, you can run the backend and frontend development servers separately. For the backend, open a terminal in the `backend/` directory and run `langgraph dev`. The backend API will be available at `http://127.0.0.1:2024`. It will also open a browser window to the LangGraph UI. For the frontend, open a terminal in the `frontend/` directory and run `npm run dev`. The frontend will be available at `http://localhost:5173`._
+_Alternatively, you can run the backend and frontend development servers separately. For the backend, open a terminal in the `backend/` directory and run `uvicorn agent.app:app --reload --port 2024`. For the frontend, open a terminal in the `frontend/` directory and run `npm run dev`. The frontend will be available at `http://localhost:5173`._
 
 ## How the Backend Agent Works (High-Level)
 
-The core of the backend is a LangGraph agent defined in `backend/src/agent/graph.py`. It follows these steps:
+The core of the backend is an agent defined in `backend/src/agent/graph.py`. It follows these steps:
 
 ![Agent Flow](./agent.png)
 
@@ -75,7 +75,7 @@ The core of the backend is a LangGraph agent defined in `backend/src/agent/graph
 
 ## Deployment
 
-In production, the backend server serves the optimized static frontend build. LangGraph requires a Redis instance and a Postgres database. Redis is used as a pub-sub broker to enable streaming real time output from background runs. Postgres is used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. For more details on how to deploy the backend server, take a look at the [LangGraph Documentation](https://langchain-ai.github.io/langgraph/concepts/deployment_options/). Below is an example of how to build a Docker image that includes the optimized frontend build and the backend server and run it via `docker-compose`.
+In production, the backend server serves the optimized static frontend build. The server requires a Redis instance and a Postgres database. Redis is used as a pub-sub broker to enable streaming real time output from background runs. Postgres is used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. Below is an example of how to build a Docker image that includes the optimized frontend build and the backend server and run it via `docker-compose`.
 
 _Note: For the docker-compose.yml example you need a LangSmith API key, you can get one from [LangSmith](https://smith.langchain.com/settings)._
 
@@ -100,7 +100,6 @@ Open your browser and navigate to `http://localhost:8123/app/` to see the applic
 - [React](https://reactjs.org/) (with [Vite](https://vitejs.dev/)) - For the frontend user interface.
 - [Tailwind CSS](https://tailwindcss.com/) - For styling.
 - [Shadcn UI](https://ui.shadcn.com/) - For components.
-- [LangGraph](https://github.com/langchain-ai/langgraph) - For building the backend research agent.
 - [Google Gemini](https://ai.google.dev/models/gemini) - LLM for query generation, reflection, and answer synthesis.
 
 ## License

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,6 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@langchain/core": "^0.3.55",
-        "@langchain/langgraph-sdk": "^0.0.74",
         "@radix-ui/react-scroll-area": "^1.2.8",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-slot": "^1.2.2",
@@ -701,78 +699,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@langchain/core": {
-      "version": "0.3.55",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.55.tgz",
-      "integrity": "sha512-SojY2ugpT6t9eYfFB9Ysvyhhyh+KJTGXs50hdHUE9tAEQWp3WAwoxe4djwJnOZ6fSpWYdpFt2UT2ksHVDy2vXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.16",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.0.74",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.74.tgz",
-      "integrity": "sha512-IUN0m4BYkGWdviFd4EaWDcQgxNq8z+1LIwXajCSt9B+Cb/pz0ZNpIPdu5hAIsf6a0RWu5yRUhzL1L40t7vu3Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.2.31 <0.4.0",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.55",
-    "@langchain/langgraph-sdk": "^0.0.74",
     "@radix-ui/react-scroll-area": "^1.2.8",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-slot": "^1.2.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useStream } from "@langchain/langgraph-sdk/react";
-import type { Message } from "@langchain/langgraph-sdk";
+import { useStream } from "@/hooks/useStream";
+import type { Message } from "@/types";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { ProcessedEvent } from "@/components/ActivityTimeline";
 import { WelcomeScreen } from "@/components/WelcomeScreen";

--- a/frontend/src/components/ChatMessagesView.tsx
+++ b/frontend/src/components/ChatMessagesView.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import type { Message } from "@langchain/langgraph-sdk";
+import type { Message } from "@/types";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, Copy, CopyCheck } from "lucide-react";
 import { InputForm } from "@/components/InputForm";

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -32,8 +32,6 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
         hasHistory={false}
       />
     </div>
-    <p className="text-xs text-neutral-500">
-      Powered by Google Gemini and LangChain LangGraph.
-    </p>
+    <p className="text-xs text-neutral-500">Powered by Google Gemini.</p>
   </div>
 );

--- a/frontend/src/hooks/useStream.ts
+++ b/frontend/src/hooks/useStream.ts
@@ -1,0 +1,61 @@
+import { useState, useRef, useCallback } from "react";
+import type { Message } from "@/types";
+
+interface Options<T> {
+  apiUrl: string;
+  assistantId: string;
+  messagesKey: string;
+  onFinish?: (event: any) => void;
+  onUpdateEvent?: (event: any) => void;
+}
+
+export function useStream<T extends Record<string, unknown>>(options: Options<T>) {
+  const { apiUrl, assistantId, messagesKey, onFinish, onUpdateEvent } = options;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const submit = useCallback(async (payload: T) => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${apiUrl}/assistants/${assistantId}/invoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      const runId = data.run_id;
+      const es = new EventSource(
+        `${apiUrl}/assistants/${assistantId}/runs/${runId}/events`
+      );
+      eventSourceRef.current = es;
+      es.onmessage = (ev) => {
+        if (ev.data === "[DONE]") {
+          setIsLoading(false);
+          es.close();
+          onFinish?.(ev);
+          return;
+        }
+        const event = JSON.parse(ev.data);
+        if (event[messagesKey]) {
+          setMessages(event[messagesKey] as Message[]);
+        }
+        onUpdateEvent?.(event);
+      };
+      es.onerror = () => {
+        es.close();
+        setIsLoading(false);
+      };
+    } catch (err) {
+      console.error(err);
+      setIsLoading(false);
+    }
+  }, [apiUrl, assistantId, messagesKey, onFinish, onUpdateEvent]);
+
+  const stop = useCallback(() => {
+    eventSourceRef.current?.close();
+    setIsLoading(false);
+  }, []);
+
+  return { messages, isLoading, submit, stop } as const;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,5 @@
+export interface Message {
+  id?: string;
+  type: "human" | "ai";
+  content: string | Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- drop `@langchain/core` and `@langchain/langgraph-sdk` from the frontend
- implement a local streaming hook and `Message` interface
- update imports to use the new hook and types
- clean LangGraph references from WelcomeScreen and README

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/gemini-ui-simple-quickstart/frontend/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68500fcbe46c833295a1e1e3bf882507